### PR TITLE
Move to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup, Command
+from setuptools import setup, Command
 import os
 
 
@@ -36,7 +36,7 @@ class DocCommand(Command):
 
 setup(
     name='VideoConverter',
-    version='1.1.5',
+    version='1.1.6',
     description='Video Converter library',
     url='https://github.com/senko/python-video-converter/',
 


### PR DESCRIPTION
setuptools absorbed distutils anyway, and some package managers (notably
sdispater/poetry) will choke trying to install this repo as-is. Moving
to setuptools fixes this issue.

An example of the error from poetry is:

```
[VenvCommandError]
Command ['python', 'setup.py', 'egg_info'] errored with the following output:
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help
error: invalid command 'egg_info'
```